### PR TITLE
Update YAML paths and version

### DIFF
--- a/input_datasets_yaml/roms_bry.yaml
+++ b/input_datasets_yaml/roms_bry.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30

--- a/input_datasets_yaml/roms_bry_bgc.yaml
+++ b/input_datasets_yaml/roms_bry_bgc.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30

--- a/input_datasets_yaml/roms_frc.yaml
+++ b/input_datasets_yaml/roms_frc.yaml
@@ -21,7 +21,7 @@ SurfaceForcing:
   end_time: '2012-02-01T00:00:00'
   source:
     name: ERA5
-    path: /global/cfs/projectdirs/m4746/Datasets/alpha/CESM_REGRIDDED/ERA5_2012-01.nc
+    path: /global/cfs/projectdirs/m4746/Datasets/alpha/ERA5/NA/2012/ERA5_2012-01.nc
     climatology: false
   type: physics
   correct_radiation: true

--- a/input_datasets_yaml/roms_frc_bgc.yaml
+++ b/input_datasets_yaml/roms_frc_bgc.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30

--- a/input_datasets_yaml/roms_grd.yaml
+++ b/input_datasets_yaml/roms_grd.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30

--- a/input_datasets_yaml/roms_ini.yaml
+++ b/input_datasets_yaml/roms_ini.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30

--- a/input_datasets_yaml/roms_riv_frc.yaml
+++ b/input_datasets_yaml/roms_riv_frc.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30

--- a/input_datasets_yaml/roms_tides.yaml
+++ b/input_datasets_yaml/roms_tides.yaml
@@ -1,5 +1,5 @@
 ---
-roms_tools_version: 2.4.0
+roms_tools_version: 2.5.0
 ---
 Grid:
   nx: 30
@@ -19,7 +19,7 @@ Grid:
 TidalForcing:
   source:
     name: TPXO
-    path: /global/cfs/projectdirs/m4746/Datasets/alpha/CESM_REGRIDDED/tpxo9.v2a.nc
+    path: /global/cfs/projectdirs/m4746/Datasets/alpha/TPXO/tpxo9.v2a.nc
   ntides: 14
   allan_factor: 2.0
   model_reference_date: '2000-01-01T00:00:00'


### PR DESCRIPTION
Some of the paths in the example yamls were incorrect for the alpha files on Perlmutter. Those are updated, as well as the ROMS-tools version in the header.