### PR TITLE
Fixing monthly_restarts to be up to date with ROMS

### DIFF
--- a/code/ocean_vars.opt
+++ b/code/ocean_vars.opt
@@ -3,6 +3,7 @@
       ! user inputs
       logical,parameter :: wrt_file_rst      = .true.     ! t/f to write module history file
       real,parameter    :: output_period_rst = 86400          ! output period in seconds
+      logical,parameter :: monthly_restarts  = .false.    ! This overrides output_period
       integer,parameter :: nrpf_rst          = 2          ! total recs per file
       
       logical,parameter :: wrt_file_his      = .true.      ! t/f to write module history file


### PR DESCRIPTION
Adds one line to `ocean_vars.opt` so that the monthly_restarts parameter doesn't throw an error. This matches what was done with the other ROMS examples here: https://github.com/CESR-lab/ucla-roms/pull/70

(I'm using the no_cstar branch to test a new ROMS+MARBL install for another project, thanks for making it available as a resource!)