### PR TITLE
run schema migration on blueprints

### DIFF
--- a/wales-toy-domain/wales_toy_blueprint.yaml
+++ b/wales-toy-domain/wales_toy_blueprint.yaml
@@ -1,30 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.2.0.0.json
 name: roms_marbl_example_wales_new_bp
 description: toy domain near wales, for fast laptop/CI runs
 application: roms_marbl
 state: draft
+schema_version: 2.0.0
+working_dir: /Users/chris/cstar/wales_toy_blueprint
 valid_start_date: 2012-01-01 00:00:00
 valid_end_date: 2012-01-31 12:00:00
-
-
 code:
   roms:
+    documentation: cworthy fork
     location: https://github.com/CWorthy-ocean/ucla-roms.git
     branch: main
-    documentation: cworthy fork
-  marbl:
-    location: https://github.com/marbl-ecosys/MARBL.git
-    branch: marbl0.45.0
-
   run_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
     branch: main
     filter:
-      files:
-        - roms.in
-        - marbl_in
-        - marbl_tracer_output_list
-        - marbl_diagnostic_output_list
       directory: wales-toy-domain/roms_runtime_code
+      files:
+      - roms.in
+      - marbl_in
+      - marbl_tracer_output_list
+      - marbl_diagnostic_output_list
   compile_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
     branch: main
@@ -40,24 +37,25 @@ code:
       - param.opt
       - tracers.opt
       - Make.depend
-
+  marbl:
+    location: https://github.com/marbl-ecosys/MARBL.git
+    branch: marbl0.45.0
+initial_conditions:
+  data:
+  - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_ini.nc
+    hash: c8eda3bab223d8f247055da5afe6a69234833733c75cba7dc6b5a85b06263d52
 grid:
   documentation: my favorite grid
   data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_grd.nc
-      hash: 41397c80fd00536dc414f6b8039b08fbe5d9f234aec66c3fc9b5a8e13353502a
-
-
-initial_conditions:
-  data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_ini.nc
-      hash: c8eda3bab223d8f247055da5afe6a69234833733c75cba7dc6b5a85b06263d52
-
+  - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_grd.nc
+    hash: 41397c80fd00536dc414f6b8039b08fbe5d9f234aec66c3fc9b5a8e13353502a
 forcing:
-  tidal:
+  boundary:
     data:
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_tides.nc
-        hash: 9466a6cacf33f3b3cbfaa87044c70cc8ef12e963f42ce3e72e30b564541afef1
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_bry.nc
+      hash: 3b51a46b1bd50d8a0e7c7f96c7b153c9d2c7fb26a8e9d97ce957d43210944909
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_bry_bgc.nc
+      hash: 366af33acf309c7644fab8f7bd5385c99123634c82d5c15f09d2033ec7103a6e
   surface:
     documentation: best forcing ever
     locked: true
@@ -66,25 +64,18 @@ forcing:
       hash: b9d1884c5175c8e690ad372d0585583ccaa04baa35bb1e8f3c0d2f2b37666829
     - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_frc_bgc.nc
       hash: f78fce51e2178adcd128ea8d92bf091a450e4245dcb023027faae8e2d3963e72
-  boundary:
+  tidal:
     data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_bry.nc
-      hash: 3b51a46b1bd50d8a0e7c7f96c7b153c9d2c7fb26a8e9d97ce957d43210944909
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_bry_bgc.nc
-      hash: 366af33acf309c7644fab8f7bd5385c99123634c82d5c15f09d2033ec7103a6e
-
-cdr_forcing:
-  data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/my_cdr_forcing.nc
-
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/roms_tides.nc
+      hash: 9466a6cacf33f3b3cbfaa87044c70cc8ef12e963f42ce3e72e30b564541afef1
 partitioning:
   n_procs_x: 3
   n_procs_y: 3
-
 model_params:
   time_step: 360
-
 runtime_params:
-  start_date: "2012-01-01 00:00:00"
-  end_date: "2012-01-01 00:30:00"
-  output_dir: "~/cstar/wales_toy_blueprint"
+  start_date: 2012-01-01 00:00:00
+  end_date: 2012-01-01 00:30:00
+cdr_forcing:
+  data:
+  - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wales-toy-domain/input_datasets_netcdf/my_cdr_forcing.nc

--- a/wales-toy-domain/wales_toy_blueprint.yaml
+++ b/wales-toy-domain/wales_toy_blueprint.yaml
@@ -4,7 +4,7 @@ description: toy domain near wales, for fast laptop/CI runs
 application: roms_marbl
 state: draft
 schema_version: 2.0.0
-working_dir: /Users/chris/cstar/wales_toy_blueprint
+working_dir: "~/cstar/wales_toy_blueprint"
 valid_start_date: 2012-01-01 00:00:00
 valid_end_date: 2012-01-31 12:00:00
 code:

--- a/wio-toy-domain/wio_toy_blueprint.yaml
+++ b/wio-toy-domain/wio_toy_blueprint.yaml
@@ -4,7 +4,7 @@ description: wio toy domain for laptop
 application: roms_marbl
 state: draft
 schema_version: 2.0.0
-working_dir: /Users/chris/cstar/wales_toy_blueprint
+working_dir: "~/cstar/wio_toy_blueprint"
 valid_start_date: 2012-01-01 00:00:00
 valid_end_date: 2012-01-02 00:00:00
 code:

--- a/wio-toy-domain/wio_toy_blueprint.yaml
+++ b/wio-toy-domain/wio_toy_blueprint.yaml
@@ -1,79 +1,75 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/CWorthy-ocean/C-Star/refs/heads/main/docs/schemas/bp/roms_marbl/roms_marbl_schema.2.0.0.json
 name: wio_toy
 description: wio toy domain for laptop
 application: roms_marbl
 state: draft
-valid_start_date: 2012-01-01
-valid_end_date: 2012-01-02
-
+schema_version: 2.0.0
+working_dir: /Users/chris/cstar/wales_toy_blueprint
+valid_start_date: 2012-01-01 00:00:00
+valid_end_date: 2012-01-02 00:00:00
 code:
   roms:
     location: https://github.com/CWorthy-ocean/ucla-roms.git
     branch: a338198af93a7b4cfa8f320a23f0f5623bc18152
-  marbl:
-    location: https://github.com/marbl-ecosys/MARBL.git
-    branch: marbl0.45.0
-
   run_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
     branch: main
     filter:
       directory: wio-toy-domain/runtime_code
       files:
-        - cson_roms-marbl_v0.1_wio-toy_10procs.in
-        - marbl_in
-        - marbl_tracer_output_list
-        - marbl_diagnostic_output_list
+      - cson_roms-marbl_v0.1_wio-toy_10procs.in
+      - marbl_in
+      - marbl_tracer_output_list
+      - marbl_diagnostic_output_list
   compile_time:
     location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example.git
     branch: main
     filter:
       directory: wio-toy-domain/compile_time_code
       files:
-        - bgc.opt
-        - bulk_frc.opt
-        - cdr_frc.opt
-        - cppdefs.opt
-        - diagnostics.opt
-        - ocean_vars.opt
-        - param.opt
-        - river_frc.opt
-        - sponge_tune.opt
-        - surf_flux.opt
-        - tides.opt
-        - tracers.opt
-        - Makefile
-grid:
-  data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_grid.nc
+      - bgc.opt
+      - bulk_frc.opt
+      - cdr_frc.opt
+      - cppdefs.opt
+      - diagnostics.opt
+      - ocean_vars.opt
+      - param.opt
+      - river_frc.opt
+      - sponge_tune.opt
+      - surf_flux.opt
+      - tides.opt
+      - tracers.opt
+      - Makefile
+  marbl:
+    location: https://github.com/marbl-ecosys/MARBL.git
+    branch: marbl0.45.0
 initial_conditions:
   data:
-    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_initial_conditions.nc
-
+  - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_initial_conditions.nc
+grid:
+  data:
+  - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_grid.nc
 forcing:
-  tidal:
-    data:
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_tidal.nc
-  surface:
-    data:
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_surface-physics_201112.nc
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_surface-physics_201201.nc
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_surface-bgc_clim.nc
   boundary:
     data:
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_boundary-physics_201201.nc
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_boundary-bgc_clim.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_boundary-physics_201201.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_boundary-bgc_clim.nc
+  surface:
+    data:
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_surface-physics_201112.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_surface-physics_201201.nc
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_surface-bgc_clim.nc
+  tidal:
+    data:
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_tidal.nc
   river:
     data:
-      - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_river.nc
-
+    - location: https://github.com/CWorthy-ocean/cstar_blueprint_roms_marbl_example/raw/refs/heads/main/wio-toy-domain/netcdf_inputs/cson_roms-marbl_v0.1_wio-toy_10procs_river.nc
 partitioning:
   n_procs_x: 2
   n_procs_y: 5
-
 model_params:
   time_step: 900
-
 runtime_params:
-  start_date: "2012-01-01 00:00:00"
-  end_date: "2012-01-01 01:00:00"
-  output_dir: "~/cstar/wales_toy_blueprint"
+  start_date: 2012-01-01 00:00:00
+  end_date: 2012-01-01 01:00:00


### PR DESCRIPTION
This change runs the schema migration tool on the blueprints contained in the repository. 